### PR TITLE
Render long-distance ferries at longer zooms

### DIFF
--- a/src/main/java/org/openmaptiles/layers/Park.java
+++ b/src/main/java/org/openmaptiles/layers/Park.java
@@ -100,9 +100,9 @@ public class Park implements
         protectionTitle = protectionTitle.replace(' ', '_').toLowerCase(Locale.ROOT);
       }
       clazz = coalesce(
-          nullIfEmpty(protectionTitle),
-          nullIfEmpty(element.boundary()),
-          nullIfEmpty(element.leisure())
+        nullIfEmpty(protectionTitle),
+        nullIfEmpty(element.boundary()),
+        nullIfEmpty(element.leisure())
       );
     }
 

--- a/src/main/java/org/openmaptiles/layers/Poi.java
+++ b/src/main/java/org/openmaptiles/layers/Poi.java
@@ -61,7 +61,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
-import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
 import org.openmaptiles.OpenMapTilesProfile;
 import org.openmaptiles.generated.OpenMapTilesSchema;

--- a/src/main/java/org/openmaptiles/layers/Transportation.java
+++ b/src/main/java/org/openmaptiles/layers/Transportation.java
@@ -609,7 +609,7 @@ public class Transportation implements
       .setAttr(Fields.LAYER, nullIfLong(element.layer(), 0))
       .setSortKey(element.zOrder())
       .setMinPixelSize(0) // merge during post-processing, then limit by size
-      .setMinZoom(11);
+      .setMinZoom(4);
   }
 
   @Override

--- a/src/main/java/org/openmaptiles/layers/Transportation.java
+++ b/src/main/java/org/openmaptiles/layers/Transportation.java
@@ -155,8 +155,6 @@ public class Transportation implements
     .put(6, 100)
     .put(5, 500)
     .put(4, 1_000);
-  // "shipway_linestring_gen_z10: ... sql_filter: ST_Length(geometry)>ZRES5", in "world coordinates"
-  private static final double FERRY_MIN_LENTH = 1 / Math.pow(2d, 13d);
   // "shipway_linestring_gen_z5: ... tolerance: ZRES6", etc. when recalculated from meters to pixels is always:
   private static final double FERRY_TOLERANCE = 0.5;
   // ORDER BY network_type, network, LENGTH(ref), ref)
@@ -625,7 +623,7 @@ public class Transportation implements
       zoom = -(Math.log(element.source().length()) / LOG2) - 3;
     } catch (GeometryException e) {
       e.log(stats, "omt_ferry_minzoom",
-          "Unable to calculate ferry minzoom for " + element.source().id());
+        "Unable to calculate ferry minzoom for " + element.source().id());
       // ferries are supposed to be included in Z4-Z10 depending on their length (=this min. zoom calculation), for Z11+ always, hence 11 as fallback
       return 11;
     }

--- a/src/main/java/org/openmaptiles/layers/Transportation.java
+++ b/src/main/java/org/openmaptiles/layers/Transportation.java
@@ -671,9 +671,9 @@ public class Transportation implements
 
   private List<VectorTile.Feature> postProcessAllOrNonFerry(int zoom, List<VectorTile.Feature> items) {
     return postProcessItems(
-        zoom,
-        items,
-        config.tolerance(zoom));
+      zoom,
+      items,
+      config.tolerance(zoom));
   }
 
   private List<VectorTile.Feature> postProcessFerry(int zoom, List<VectorTile.Feature> items) {
@@ -697,7 +697,7 @@ public class Transportation implements
       }
       var result = postProcessFerry(zoom, ferryItems);
       result.addAll(postProcessAllOrNonFerry(zoom, otherItems));
-      return  result;
+      return result;
     }
   }
 

--- a/src/main/java/org/openmaptiles/layers/Transportation.java
+++ b/src/main/java/org/openmaptiles/layers/Transportation.java
@@ -606,7 +606,7 @@ public class Transportation implements
     try {
       // In OpenMapTiles there are different limits (in kilometers) per zoom level which we are not able to do here.
       // Hence, we do at least filter on `min(ZRES5, ZRES4, ...)`, e.g. ZRES5, for all zoom levels here:
-      // we get what we want at Z10 and only "few more" are Z4-Z9.
+      // we get what we want at Z10 and only "few more" at Z4-Z9.
       if (element.source().length() < FERRY_MIN_LENTH) {
         return;
       }

--- a/src/main/java/org/openmaptiles/layers/Transportation.java
+++ b/src/main/java/org/openmaptiles/layers/Transportation.java
@@ -670,10 +670,7 @@ public class Transportation implements
   }
 
   private List<VectorTile.Feature> postProcessAllOrNonFerry(int zoom, List<VectorTile.Feature> items) {
-    return postProcessItems(
-      zoom,
-      items,
-      config.tolerance(zoom));
+    return postProcessItems(zoom, items, config.tolerance(zoom));
   }
 
   private List<VectorTile.Feature> postProcessFerry(int zoom, List<VectorTile.Feature> items) {

--- a/src/test/java/org/openmaptiles/layers/AbstractLayerTest.java
+++ b/src/test/java/org/openmaptiles/layers/AbstractLayerTest.java
@@ -137,6 +137,16 @@ public abstract class AbstractLayerTest {
     );
   }
 
+  SourceFeature lineFeatureWithLength(double length, Map<String, Object> props) {
+    return SimpleFeature.create(
+      GeoUtils.worldToLatLonCoords(newLineString(0, 0, 0, length)),
+      new HashMap<>(props),
+      OpenMapTilesProfile.OSM_SOURCE,
+      null,
+      0
+    );
+  }
+
   SourceFeature closedWayFeature(Map<String, Object> props) {
     return SimpleFeature.createFakeOsmFeature(
       newLineString(0, 0, 1, 0, 1, 1, 0, 1, 0, 0),

--- a/src/test/java/org/openmaptiles/layers/ParkTest.java
+++ b/src/test/java/org/openmaptiles/layers/ParkTest.java
@@ -48,24 +48,24 @@ class ParkTest extends AbstractLayerTest {
   @Test
   void testAbotiginalLand() {
     assertFeatures(13, List.of(Map.of(
-        "_layer", "park",
-        "_type", "polygon",
-        "class", "aboriginal_lands",
-        "name", "Hualapai Tribe",
-        "_minpixelsize", 2d,
-        "_minzoom", 4,
-        "_maxzoom", 14
+      "_layer", "park",
+      "_type", "polygon",
+      "class", "aboriginal_lands",
+      "name", "Hualapai Tribe",
+      "_minpixelsize", 2d,
+      "_minzoom", 4,
+      "_maxzoom", 14
     ), Map.of(
-        "_layer", "park",
-        "_type", "point",
-        "class", "aboriginal_lands",
-        "name", "Hualapai Tribe",
-        "_minzoom", 5,
-        "_maxzoom", 14
+      "_layer", "park",
+      "_type", "point",
+      "class", "aboriginal_lands",
+      "name", "Hualapai Tribe",
+      "_minzoom", 5,
+      "_maxzoom", 14
     )), process(polygonFeature(Map.of(
-        "boundary", "aboriginal_lands",
-        "name", "Hualapai Tribe",
-        "protection_title", "National Park"
+      "boundary", "aboriginal_lands",
+      "name", "Hualapai Tribe",
+      "protection_title", "National Park"
     ))));
   }
 

--- a/src/test/java/org/openmaptiles/layers/TransportationTest.java
+++ b/src/test/java/org/openmaptiles/layers/TransportationTest.java
@@ -2038,13 +2038,13 @@ class TransportationTest extends AbstractLayerTest {
 
     for (var entry : testEntries) {
       assertFeatures(14, List.of(Map.of(
-          "_layer", "transportation",
-          "class", "ferry",
-          "_minzoom", entry.expectedZoom,
-          "_maxzoom", 14
+        "_layer", "transportation",
+        "class", "ferry",
+        "_minzoom", entry.expectedZoom,
+        "_maxzoom", 14
       ), Map.of(
-          "_layer", "transportation_name",
-          "_type", "line"
+        "_layer", "transportation_name",
+        "_type", "line"
       )), process(entry.feature));
       /*
       process(entry.feature);

--- a/src/test/java/org/openmaptiles/layers/TransportationTest.java
+++ b/src/test/java/org/openmaptiles/layers/TransportationTest.java
@@ -1747,7 +1747,7 @@ class TransportationTest extends AbstractLayerTest {
       "_layer", "transportation",
       "class", "ferry",
 
-      "_minzoom", 11,
+      "_minzoom", 4,
       "_maxzoom", 14,
       "_type", "line"
     ), Map.of(

--- a/src/test/java/org/openmaptiles/layers/TransportationTest.java
+++ b/src/test/java/org/openmaptiles/layers/TransportationTest.java
@@ -1793,7 +1793,7 @@ class TransportationTest extends AbstractLayerTest {
       "_layer", "transportation",
       "class", "ferry",
 
-      "_minzoom", 4,
+      "_minzoom", 5,
       "_maxzoom", 14,
       "_type", "line"
     ), Map.of(

--- a/src/test/java/org/openmaptiles/layers/TransportationTest.java
+++ b/src/test/java/org/openmaptiles/layers/TransportationTest.java
@@ -13,6 +13,7 @@ import com.onthegomap.planetiler.reader.SimpleFeature;
 import com.onthegomap.planetiler.reader.SourceFeature;
 import com.onthegomap.planetiler.reader.osm.OsmElement;
 import com.onthegomap.planetiler.stats.Stats;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -1996,5 +1997,58 @@ class TransportationTest extends AbstractLayerTest {
       "tracktype", "grade1",
       "highway", "track"
     ))));
+  }
+
+  private record TestEntry(
+    SourceFeature feature,
+    int expectedZoom
+  ) {}
+
+  private void createFerryForMinZoomTest(List<TestEntry> testEntries, double length, int expectedZoom, String name) {
+    var feature = lineFeatureWithLength(length, Map.of(
+      "name", name,
+      "route", "ferry"
+    ));
+    testEntries.add(new TestEntry(
+      feature,
+      Math.min(11, Math.max(4, expectedZoom))
+    ));
+  }
+
+  @Test
+  void testGetFerryMinzoom() throws GeometryException {
+    // Threshold is 1/8 of tile size, hence ...
+    // ... side is 1/8 tile side: from pixels to world coord, for say Z14 ...
+    //final double PORTION_OF_TILE_SIDE = (256d / 8) / Math.pow(2d, 14d + 8d);
+    // ... and then for some lower zoom:
+    //double testLineSide = PORTION_OF_TILE_SIDE * Math.pow(2, 14 - zoom);
+    // all this then simplified to `testLength` calculation bellow
+
+    final List<TestEntry> testEntries = new ArrayList<>();
+    for (int zoom = 14; zoom >= 0; zoom--) {
+      double testLength = Math.pow(2, -zoom - 3);
+
+      // slightly bellow the threshold
+      createFerryForMinZoomTest(testEntries, testLength * 0.999, zoom + 1, "ferry-");
+      // precisely at the threshold
+      createFerryForMinZoomTest(testEntries, testLength, zoom, "ferry=");
+      // slightly over the threshold
+      createFerryForMinZoomTest(testEntries, testLength * 1.001, zoom, "ferry+");
+    }
+
+    for (var entry : testEntries) {
+      assertFeatures(14, List.of(Map.of(
+          "_layer", "transportation",
+          "class", "ferry",
+          "_minzoom", entry.expectedZoom,
+          "_maxzoom", 14
+      ), Map.of(
+          "_layer", "transportation_name",
+          "_type", "line"
+      )), process(entry.feature));
+      /*
+      process(entry.feature);
+       */
+    }
   }
 }

--- a/src/test/java/org/openmaptiles/layers/TransportationTest.java
+++ b/src/test/java/org/openmaptiles/layers/TransportationTest.java
@@ -1932,24 +1932,24 @@ class TransportationTest extends AbstractLayerTest {
   @Test
   void testGrade1SurfacePath() {
     assertFeatures(14, List.of(Map.of(
-        "_layer", "transportation",
-        "class", "track",
-        "surface", "paved"
+      "_layer", "transportation",
+      "class", "track",
+      "surface", "paved"
     )), process(lineFeature(Map.of(
-        "surface", "grade1",
-        "highway", "track"
+      "surface", "grade1",
+      "highway", "track"
     ))));
   }
 
   @Test
   void testGrade1TracktypePath() {
     assertFeatures(14, List.of(Map.of(
-        "_layer", "transportation",
-        "class", "track",
-        "surface", "paved"
+      "_layer", "transportation",
+      "class", "track",
+      "surface", "paved"
     )), process(lineFeature(Map.of(
-        "tracktype", "grade1",
-        "highway", "track"
+      "tracktype", "grade1",
+      "highway", "track"
     ))));
   }
 }


### PR DESCRIPTION
This re-implements following OpenMapTiles pull-request into `planetiler-openmaptiles`:

* https://github.com/openmaptiles/openmaptiles/pull/1486

Some screenshots, roughly same area as in "1486", same zoom levels:

* Z4:

![Screenshot from 2023-10-18 15-37-48](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/ded1c092-edfb-41d2-8cea-0ad46d452d71)

* Z5:

![Screenshot from 2023-10-18 15-38-38](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/bb4f192a-35d0-4d60-ab03-e80c5dbdc57a)

* Z10: just for illustration, since Z10 as this is already in 3.14

![Screenshot from 2023-10-18 15-39-42](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/3a562768-f552-470a-8486-7a06b13ca70d)
