### PR TITLE
Convert semi-colon separated house numbers to a range

### DIFF
--- a/src/test/java/org/openmaptiles/layers/HousenumberTest.java
+++ b/src/test/java/org/openmaptiles/layers/HousenumberTest.java
@@ -1,5 +1,7 @@
 package org.openmaptiles.layers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -26,5 +28,44 @@ class HousenumberTest extends AbstractLayerTest {
     )), process(polygonFeature(Map.of(
       "addr:housenumber", "10"
     ))));
+  }
+
+  @Test
+  void testDisplayHousenumberNonRange() {
+    final String HOUSENUMBER = "1";
+    assertEquals(HOUSENUMBER, Housenumber.displayHousenumber(HOUSENUMBER));
+  }
+
+  @Test
+  void testDisplayHousenumberNumericRange() {
+    final String HOUSENUMBER = "1;1a;2;2/b;20;3";
+    assertEquals("1–3", Housenumber.displayHousenumber(HOUSENUMBER));
+  }
+
+  @Test
+  void testDisplayHousenumberNumericRangeBroken() {
+    final String HOUSENUMBER = "1;1a;2;2/b;20;3;";
+    assertEquals("1–3", Housenumber.displayHousenumber(HOUSENUMBER));
+  }
+
+  @Test
+  void testDisplayHousenumberNonnumericRange() {
+    final String HOUSENUMBER = "1;2;20;3";
+    assertEquals("1–20", Housenumber.displayHousenumber(HOUSENUMBER));
+  }
+
+  @Test
+  void testDisplayHousenumberNonnumericRangeBroken() {
+    final String HOUSENUMBER = "1;2;20;3;";
+    assertEquals("1–20", Housenumber.displayHousenumber(HOUSENUMBER));
+  }
+
+  @Test
+  void testDisplayHousenumberExtraBroken() {
+    final String HOUSENUMBER_1 = ";";
+    assertEquals(HOUSENUMBER_1, Housenumber.displayHousenumber(HOUSENUMBER_1));
+
+    final String HOUSENUMBER_2 = ";;";
+    assertEquals(HOUSENUMBER_2, Housenumber.displayHousenumber(HOUSENUMBER_2));
   }
 }

--- a/src/test/java/org/openmaptiles/layers/HousenumberTest.java
+++ b/src/test/java/org/openmaptiles/layers/HousenumberTest.java
@@ -37,25 +37,25 @@ class HousenumberTest extends AbstractLayerTest {
   }
 
   @Test
-  void testDisplayHousenumberNumericRange() {
+  void testDisplayHousenumberNonnumericRange() {
     final String HOUSENUMBER = "1;1a;2;2/b;20;3";
     assertEquals("1–3", Housenumber.displayHousenumber(HOUSENUMBER));
   }
 
   @Test
-  void testDisplayHousenumberNumericRangeBroken() {
+  void testDisplayHousenumberNonnumericRangeBroken() {
     final String HOUSENUMBER = "1;1a;2;2/b;20;3;";
     assertEquals("1–3", Housenumber.displayHousenumber(HOUSENUMBER));
   }
 
   @Test
-  void testDisplayHousenumberNonnumericRange() {
+  void testDisplayHousenumberNumericRange() {
     final String HOUSENUMBER = "1;2;20;3";
     assertEquals("1–20", Housenumber.displayHousenumber(HOUSENUMBER));
   }
 
   @Test
-  void testDisplayHousenumberNonnumericRangeBroken() {
+  void testDisplayHousenumberNumericRangeBroken() {
     final String HOUSENUMBER = "1;2;20;3;";
     assertEquals("1–20", Housenumber.displayHousenumber(HOUSENUMBER));
   }


### PR DESCRIPTION
This re-implements following OpenMapTiles pull-request into `planetiler-openmaptiles`:

* https://github.com/openmaptiles/openmaptiles/pull/1562

Some screenshot, roughly same area as in "1562", same zoom levels:

![Screenshot from 2023-10-09 20-39-15](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/b1595de7-0ae3-4b44-b405-5a2c435249f3)
