### PR TITLE
fix for diff in transportation name

### DIFF
--- a/src/main/java/org/openmaptiles/layers/TransportationName.java
+++ b/src/main/java/org/openmaptiles/layers/TransportationName.java
@@ -109,8 +109,8 @@ public class TransportationName implements
     .put(7, 20_000)
     .put(8, 14_000)
     .put(9, 8_000)
-    .put(10, 8_000)
-    .put(11, 8_000);
+    .put(10, 4_000)
+    .put(11, 2_000);
   private static final List<String> CONCURRENT_ROUTE_KEYS = List.of(
     Fields.ROUTE_1,
     Fields.ROUTE_2,


### PR DESCRIPTION
Differences in contents of `transportation_name` layer are observed between output generated by OpenMapTiles and Planetiler. This addresses what discrepancy observed in Planetiler's handling of "min length" at Z10 and Z11.