### PR TITLE
Fix for agg_stop implementation

### DIFF
--- a/src/main/java/org/openmaptiles/layers/Poi.java
+++ b/src/main/java/org/openmaptiles/layers/Poi.java
@@ -175,8 +175,12 @@ public class Poi implements
   public void process(Tables.OsmPoiPoint element, FeatureCollector features) {
     if (element.uicRef() != null && AGG_STOP_SUBCLASS_ORDER.contains(element.subclass())) {
       // multiple threads may update this concurrently
+      String aggStopKey = element.uicRef()
+          .concat(coalesce(nullIfEmpty(element.name()), ""))
+          .concat(coalesce(nullIfEmpty(element.network()), ""))
+          .concat(coalesce(nullIfEmpty(element.operator()), ""));
       synchronized (this) {
-        aggStops.computeIfAbsent(element.uicRef(), key -> new ArrayList<>()).add(element);
+        aggStops.computeIfAbsent(aggStopKey, key -> new ArrayList<>()).add(element);
       }
     } else {
       setupPoiFeature(element, features.point(LAYER_NAME), null);


### PR DESCRIPTION
Follow-up on https://github.com/phanecak-maptiler/planetiler-openmaptiles/pull/10 : fixes outliers (e.g. stations which were put together even if quite far apart), typically:

* https://www.openstreetmap.org/node/1861342961 vs. https://www.openstreetmap.org/node/2037050203 + https://www.openstreetmap.org/node/2037050384
   * this one is most extreme as per distance and also same stop name (and even same municipality name)
* https://www.openstreetmap.org/node/399046231 + https://www.openstreetmap.org/node/399046240 vs. https://www.openstreetmap.org/node/333765438 + https://www.openstreetmap.org/node/333765434

Tested (again, also) on Switzerland (same location as for OMT: 19.29/47.3642186/8.5311424):

![Screenshot from 2023-11-20 23-01-01](https://github.com/openmaptiles/planetiler-openmaptiles/assets/115141505/d8506291-9484-4187-b3bb-7c99557b6da2)

Skipping review, to be done within https://github.com/openmaptiles/planetiler-openmaptiles/pull/126 .