### PR TITLE
areaToMinZoom refactor

### DIFF
--- a/src/main/java/org/openmaptiles/layers/Poi.java
+++ b/src/main/java/org/openmaptiles/layers/Poi.java
@@ -155,12 +155,7 @@ public class Poi implements
 
   public static int uniAreaToMinZoom(double areaWorld) {
     double oneSideWorld = Math.sqrt(areaWorld);
-    // adjusted formula from `Utils.getMinZoomForLength()`, given that 1/10 does not match `1 / (2^<something>)`
     double zoom = -(Math.log(oneSideWorld * SQRT10) / LOG2);
-
-    // Say Z13.01 means bellow threshold, Z13.00 is exactly threshold, Z12.99 is over threshold,
-    // hence Z13.01 and Z13.00 will be rounded to Z14 and Z12.99 to Z13 (e.g. `floor() + 1`).
-    // And to accommodate for some precision errors (observed for Z9-Z11) we do also `- 0.1e-10`.
     int result = (int) Math.floor(zoom - 0.1e-10) + 1;
 
     return Math.clamp(result, 10, 14);

--- a/src/main/java/org/openmaptiles/layers/TransportationName.java
+++ b/src/main/java/org/openmaptiles/layers/TransportationName.java
@@ -279,9 +279,9 @@ public class TransportationName implements
     }
 
     if (brunnel) {
-      String brunnelValue = brunnel(element.isBridge(), element.isTunnel(), element.isFord());
-      int brunnelMinzoom = brunnelValue != null ? transportation.getBrunnelMinzoom(element) : minzoom;
-      feature.setAttrWithMinzoom(Fields.BRUNNEL, brunnelValue, brunnelMinzoom);
+      // from OMT: "Drop brunnel if length of way < 2% of tile width (less than 3 pixels)"
+      feature.setAttrWithMinSize(Fields.BRUNNEL, brunnel(element.isBridge(), element.isTunnel(), element.isFord()),
+        3, 4, 12);
     }
 
     /*

--- a/src/main/java/org/openmaptiles/layers/WaterName.java
+++ b/src/main/java/org/openmaptiles/layers/WaterName.java
@@ -56,7 +56,6 @@ import org.openmaptiles.OpenMapTilesProfile;
 import org.openmaptiles.generated.OpenMapTilesSchema;
 import org.openmaptiles.generated.Tables;
 import org.openmaptiles.util.OmtLanguageUtils;
-import org.openmaptiles.util.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -211,7 +210,7 @@ public class WaterName implements
         // otherwise just use a label point inside the lake
         feature = features.pointOnSurface(LAYER_NAME)
           .setMinZoom(place != null && SEA_OR_OCEAN_PLACE.contains(place) ? 0 : 3)
-          .setMinPixelSize(128);  // tiles are 256x256, so 128x128 is 1/4 of a tile
+          .setMinPixelSize(128); // tiles are 256x256, so 128x128 is 1/4 of a tile
       }
       feature
         .setAttr(Fields.CLASS, clazz)

--- a/src/main/java/org/openmaptiles/layers/WaterName.java
+++ b/src/main/java/org/openmaptiles/layers/WaterName.java
@@ -167,6 +167,11 @@ public class WaterName implements
       if ("ocean".equals(element.place())) {
         minZoom = 0;
       } else if (rank != null) {
+        // FIXME: While this looks like matching properly stuff in https://github.com/openmaptiles/openmaptiles/pull/1457/files#diff-201daa1c61c99073fe3280d440c9feca5ed2236b251ad454caa14cc203f952d1R74 ,
+        // it includes not just https://www.openstreetmap.org/relation/13360255 but also https://www.openstreetmap.org/node/1385157299 (and some others).
+        // Hence check how that OpenMapTiles code works for "James Bay" and:
+        // a) if same as here then, fix there and then here
+        // b) if OK (while here NOK), fix only here
         minZoom = rank;
       } else if ("bay".equals(element.natural())) {
         minZoom = 13;
@@ -185,49 +190,35 @@ public class WaterName implements
   @Override
   public void process(Tables.OsmWaterPolygon element, FeatureCollector features) {
     if (nullIfEmpty(element.name()) != null) {
-      try {
-        Geometry centerlineGeometry = lakeCenterlines.get(element.source().id());
-        FeatureCollector.Feature feature;
-        int minzoom = 9;
-        String place = element.place();
-        String clazz;
-        if ("bay".equals(element.natural())) {
-          clazz = FieldValues.CLASS_BAY;
-        } else if ("sea".equals(place)) {
-          clazz = FieldValues.CLASS_SEA;
-        } else {
-          clazz = FieldValues.CLASS_LAKE;
-          minzoom = 3;
-        }
-        if (centerlineGeometry != null) {
-          // prefer lake centerline if it exists
-          feature = features.geometry(LAYER_NAME, centerlineGeometry)
-            .setMinPixelSizeBelowZoom(13, 6d * element.name().length());
-        } else {
-          // otherwise just use a label point inside the lake
-          feature = features.pointOnSurface(LAYER_NAME);
-          double area = element.source().area();
-          if (place != null && SEA_OR_OCEAN_PLACE.contains(place)) {
-            minzoom = areaToMinZoom(area, 0);
-          } else {
-            minzoom = areaToMinZoom(area, 3);
-          }
-        }
-        feature
-          .setAttr(Fields.CLASS, clazz)
-          .setBufferPixels(BUFFER_SIZE)
-          .putAttrs(OmtLanguageUtils.getNames(element.source().tags(), translations))
-          .setAttr(Fields.INTERMITTENT, element.isIntermittent() ? 1 : 0)
-          .setMinZoom(minzoom);
-      } catch (GeometryException e) {
-        e.log(stats, "omt_water_polygon", "Unable to get geometry for water polygon " + element.source().id());
+      Geometry centerlineGeometry = lakeCenterlines.get(element.source().id());
+      FeatureCollector.Feature feature;
+      int minzoom = 9;
+      String place = element.place();
+      String clazz;
+      if ("bay".equals(element.natural())) {
+        clazz = FieldValues.CLASS_BAY;
+      } else if ("sea".equals(place)) {
+        clazz = FieldValues.CLASS_SEA;
+      } else {
+        clazz = FieldValues.CLASS_LAKE;
+        minzoom = 3;
       }
+      if (centerlineGeometry != null) {
+        // prefer lake centerline if it exists
+        feature = features.geometry(LAYER_NAME, centerlineGeometry)
+          .setMinPixelSizeBelowZoom(13, 6d * element.name().length());
+      } else {
+        // otherwise just use a label point inside the lake
+        feature = features.pointOnSurface(LAYER_NAME)
+          .setMinZoom(place != null && SEA_OR_OCEAN_PLACE.contains(place) ? 0 : 3)
+          .setMinPixelSize(128);  // tiles are 256x256, so 128x128 is 1/4 of a tile
+      }
+      feature
+        .setAttr(Fields.CLASS, clazz)
+        .setBufferPixels(BUFFER_SIZE)
+        .putAttrs(OmtLanguageUtils.getNames(element.source().tags(), translations))
+        .setAttr(Fields.INTERMITTENT, element.isIntermittent() ? 1 : 0)
+        .setMinZoom(minzoom);
     }
-  }
-
-  public static int areaToMinZoom(double areaWorld, int minLimit) {
-    double oneSideWorld = Math.sqrt(areaWorld);
-    // OMT does "feature area is 1/4 of tile area", which is same as "feature side is 1/2 of tile side"
-    return Utils.getClippedMinZoomForLength(oneSideWorld, 1, minLimit, 14);
   }
 }

--- a/src/main/java/org/openmaptiles/util/Utils.java
+++ b/src/main/java/org/openmaptiles/util/Utils.java
@@ -76,44 +76,4 @@ public class Utils {
   public static String brunnel(boolean isBridge, boolean isTunnel, boolean isFord) {
     return isBridge ? "bridge" : isTunnel ? "tunnel" : isFord ? "ford" : null;
   }
-
-  /**
-   * Calculate minzoom for a feature with given length based on threshold: if a feature's length is least
-   * {@code 1 / (2^threshold)} of a tile at certain zoom level, it will be shown at that and higher zoom levels, e.g.
-   * that particular zoom level is minzoom.
-   * <p>
-   * {@code threshold} is calculated in such way to avoid calculating log(2) os it during the runtime. Use 1 for 1/2, 2
-   * for 1/4, 3 for 1/8, etc.
-   * 
-   * @param length    length of the feature
-   * @param threshold threshold
-   * @return minzoom for a feature with given length and given threshold
-   */
-  public static int getMinZoomForLength(double length, double threshold) {
-    // Say threshold is 1/8 (threshold variable = 8) of tile size, hence ...
-    // ... from pixels to world coord, for say Z14, the minimum length is:
-    //  PORTION_OF_TILE_SIDE = (256d / 8) / Math.pow(2d, 14d + 8d);
-    // ... and then minimum length for some lower zoom:
-    //  PORTION_OF_TILE_SIDE * Math.pow(2, 14 - zoom);
-    // all this then reversed and simplified to:
-    double zoom = -(Math.log(length) / LOG2) - threshold;
-
-    // Say Z13.01 means bellow threshold, Z13.00 is exactly threshold, Z12.99 is over threshold,
-    // hence Z13.01 and Z13.00 will be rounded to Z14 and Z12.99 to Z13 (e.g. `floor() + 1`).
-    // And to accommodate for some precision errors (observed for Z9-Z11) we do also `- 0.1e-10`.
-    return (int) Math.floor(zoom - 0.1e-10) + 1;
-  }
-
-  /**
-   * Same as {@link #getMinZoomForLength(double, double)} but with result within the given minimum and maximim.
-   * 
-   * @param length    length of the feature
-   * @param threshold threshold
-   * @param min       clip the result to this value if lower
-   * @param max       clip the result to this value if higher
-   * @return minzoom for a feature with given length and given threshold clipped to not exceed given minimum and maximum
-   */
-  public static int getClippedMinZoomForLength(double length, double threshold, int min, int max) {
-    return Math.clamp(getMinZoomForLength(length, threshold), min, max);
-  }
 }

--- a/src/test/java/org/openmaptiles/layers/TransportationTest.java
+++ b/src/test/java/org/openmaptiles/layers/TransportationTest.java
@@ -2020,54 +2020,6 @@ class TransportationTest extends AbstractLayerTest {
     int expectedZoom
   ) {}
 
-  private void createBrunnelForMinZoomTest(List<TestEntry> testEntries, double length, int expectedZoom, String name) {
-    var feature = lineFeatureWithLength(length, Map.of(
-      "name", name,
-      "bridge", "yes",
-      "highway", "motorway"
-    ));
-    testEntries.add(new TestEntry(
-      feature,
-      Math.clamp(expectedZoom, 4, 12)
-    ));
-  }
-
-  @Test
-  void testGetBrunnelMinzoom() throws GeometryException {
-    final List<TestEntry> testEntries = new ArrayList<>();
-    for (int zoom = 14; zoom >= 0; zoom--) {
-      double testLength = Math.pow(2, -zoom - 6);
-
-      // slightly bellow the threshold
-      createBrunnelForMinZoomTest(testEntries, testLength * 0.999, zoom + 1, "brunnel-");
-      // precisely at the threshold
-      createBrunnelForMinZoomTest(testEntries, testLength, zoom, "brunnel=");
-      // slightly over the threshold
-      createBrunnelForMinZoomTest(testEntries, testLength * 1.001, zoom, "brunnel+");
-    }
-
-    for (var entry : testEntries) {
-      var result = process(entry.feature);
-
-      assertFeatures(entry.expectedZoom, List.of(Map.of(
-        "_layer", "transportation",
-        "_type", "line",
-        "class", "motorway",
-        "brunnel", "bridge"
-      ), Map.of(
-        "_layer", "transportation_name",
-        "_type", "line"
-      )), result);
-
-      assertFeatures(entry.expectedZoom - 1, List.of(Map.of(
-        "_layer", "transportation",
-        "brunnel", "<null>"
-      ), Map.of(
-        "_layer", "transportation_name"
-      )), result);
-    }
-  }
-
   private void createFerryForMinZoomTest(List<TestEntry> testEntries, double length, int expectedZoom, String name) {
     var feature = lineFeatureWithLength(length, Map.of(
       "name", name,
@@ -2103,9 +2055,6 @@ class TransportationTest extends AbstractLayerTest {
         "_layer", "transportation_name",
         "_type", "line"
       )), process(entry.feature));
-      /*
-      process(entry.feature);
-       */
     }
   }
 

--- a/src/test/java/org/openmaptiles/layers/WaterNameTest.java
+++ b/src/test/java/org/openmaptiles/layers/WaterNameTest.java
@@ -39,6 +39,7 @@ class WaterNameTest extends AbstractLayerTest {
       "water", "pond",
       "intermittent", "1"
     ))));
+    /* TODO: remove, since `setMinPixelSize()` is now used and this no longer makes sense, as minzoom is always 3
     // 1/4 th of tile area is the threshold, 1/4 = 0.25 => area->side:0.25->0.5 => slightly bigger -> 0.51
     double z11area = Math.pow(0.51d / Math.pow(2, 11), 2);
     assertFeatures(10, List.of(Map.of(
@@ -46,15 +47,17 @@ class WaterNameTest extends AbstractLayerTest {
     ), Map.of(
       "_layer", "water_name",
       "_type", "point",
-      "_minzoom", 11,
+      "_minzoom", 3,
       "_maxzoom", 14
     )), process(polygonFeatureWithArea(z11area, Map.of(
       "name", "waterway",
       "natural", "water",
       "water", "pond"
     ))));
+     */
   }
 
+  /* TODO: remove, since `setMinPixelSize()` is now used and this no longer makes sense, as minzoom is always 3
   // https://zelonewolf.github.io/openstreetmap-americana/#map=13/41.43989/-71.5716
   @Test
   void testWordenPondNamePoint() {
@@ -63,7 +66,7 @@ class WaterNameTest extends AbstractLayerTest {
     ), Map.of(
       "_layer", "water_name",
       "_type", "point",
-      "_minzoom", 13,
+      "_minzoom", 3,
       "_maxzoom", 14
     )), process(polygonFeatureWithArea(4.930387948170328E-9, Map.of(
       "name", "waterway",
@@ -71,6 +74,7 @@ class WaterNameTest extends AbstractLayerTest {
       "water", "pond"
     ))));
   }
+   */
 
   @Test
   void testWaterNameLakeline() {
@@ -272,38 +276,5 @@ class WaterNameTest extends AbstractLayerTest {
       feature,
       Math.clamp(expectedZoom, 3, 14)
     ));
-  }
-
-  @Test
-  void testAreaToMinZoom() throws GeometryException {
-    // threshold is 1/4 of tile area, hence ...
-    // ... side is 1/2 tile side: from pixels to world coord, for say Z14 ...
-    //final double HALF_OF_TILE_SIDE = 128d / Math.pow(2d, 14d + 8d);
-    // ... and then for some lower zoom:
-    //double testAreaSide = HALF_OF_TILE_SIDE * Math.pow(2, 14 - zoom);
-    // all this then simplified to `testAreaSide` calculation bellow
-
-    final List<TestEntry> testEntries = new ArrayList<>();
-    for (int zoom = 14; zoom >= 0; zoom--) {
-      double testAreaSide = Math.pow(2, -zoom - 1);
-
-      // slightly bellow the threshold
-      createAreaForMinZoomTest(testEntries, testAreaSide * 0.999, zoom + 1, "waterway-");
-      // precisely at the threshold
-      createAreaForMinZoomTest(testEntries, testAreaSide, zoom, "waterway=");
-      // slightly over the threshold
-      createAreaForMinZoomTest(testEntries, testAreaSide * 1.001, zoom, "waterway+");
-    }
-
-    for (var entry : testEntries) {
-      assertFeatures(10, List.of(Map.of(
-        "_layer", "water"
-      ), Map.of(
-        "_layer", "water_name",
-        "_type", "point",
-        "_minzoom", entry.expectedZoom,
-        "_maxzoom", 14
-      )), process(entry.feature));
-    }
   }
 }

--- a/src/test/java/org/openmaptiles/layers/WaterNameTest.java
+++ b/src/test/java/org/openmaptiles/layers/WaterNameTest.java
@@ -39,42 +39,7 @@ class WaterNameTest extends AbstractLayerTest {
       "water", "pond",
       "intermittent", "1"
     ))));
-    /* TODO: remove, since `setMinPixelSize()` is now used and this no longer makes sense, as minzoom is always 3
-    // 1/4 th of tile area is the threshold, 1/4 = 0.25 => area->side:0.25->0.5 => slightly bigger -> 0.51
-    double z11area = Math.pow(0.51d / Math.pow(2, 11), 2);
-    assertFeatures(10, List.of(Map.of(
-      "_layer", "water"
-    ), Map.of(
-      "_layer", "water_name",
-      "_type", "point",
-      "_minzoom", 3,
-      "_maxzoom", 14
-    )), process(polygonFeatureWithArea(z11area, Map.of(
-      "name", "waterway",
-      "natural", "water",
-      "water", "pond"
-    ))));
-     */
   }
-
-  /* TODO: remove, since `setMinPixelSize()` is now used and this no longer makes sense, as minzoom is always 3
-  // https://zelonewolf.github.io/openstreetmap-americana/#map=13/41.43989/-71.5716
-  @Test
-  void testWordenPondNamePoint() {
-    assertFeatures(10, List.of(Map.of(
-      "_layer", "water"
-    ), Map.of(
-      "_layer", "water_name",
-      "_type", "point",
-      "_minzoom", 3,
-      "_maxzoom", 14
-    )), process(polygonFeatureWithArea(4.930387948170328E-9, Map.of(
-      "name", "waterway",
-      "natural", "water",
-      "water", "pond"
-    ))));
-  }
-   */
 
   @Test
   void testWaterNameLakeline() {
@@ -259,22 +224,5 @@ class WaterNameTest extends AbstractLayerTest {
       "name", "Atlantic",
       "place", "sea"
     ))));
-  }
-
-  private record TestEntry(
-    SourceFeature feature,
-    int expectedZoom
-  ) {}
-
-  private void createAreaForMinZoomTest(List<TestEntry> testEntries, double side, int expectedZoom, String name) {
-    double area = Math.pow(side, 2);
-    var feature = polygonFeatureWithArea(area, Map.of(
-      "name", name,
-      "natural", "water"
-    ));
-    testEntries.add(new TestEntry(
-      feature,
-      Math.clamp(expectedZoom, 3, 14)
-    ));
   }
 }

--- a/src/test/java/org/openmaptiles/layers/WaterNameTest.java
+++ b/src/test/java/org/openmaptiles/layers/WaterNameTest.java
@@ -5,10 +5,7 @@ import static com.onthegomap.planetiler.TestUtils.rectangle;
 
 import com.onthegomap.planetiler.TestUtils;
 import com.onthegomap.planetiler.geo.GeoUtils;
-import com.onthegomap.planetiler.geo.GeometryException;
 import com.onthegomap.planetiler.reader.SimpleFeature;
-import com.onthegomap.planetiler.reader.SourceFeature;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
Replacement of `areaToMinZoom()` with newly added (or adjusted) `setMinPixelSize()`, `setAttrWithMinSize()`, etc.

`getFerryMinzoom()` kept since we'd like to replicate `sql_filter: ST_Length(...` from OMT, see https://github.com/openmaptiles/openmaptiles/pull/1486/files#diff-99ac0a9984b09304a39d8a53146cdbee218ca1999fbcc6e34092698a69a38e1f . The difference is as follows:

![Screenshot from 2023-11-21 20-30-19](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/14010e6e-0366-45c8-ba0f-c5e92f4ff806)

Skipping review, to be done within https://github.com/openmaptiles/planetiler-openmaptiles/pull/126 .