### PR TITLE
Adjustment of MIN_LENGTH for transportation_name

### DIFF
--- a/src/main/java/org/openmaptiles/layers/TransportationName.java
+++ b/src/main/java/org/openmaptiles/layers/TransportationName.java
@@ -106,18 +106,13 @@ public class TransportationName implements
   private static final String LINK_TEMP_KEY = "__islink";
   private static final String RELATION_ID_TEMP_KEY = "__relid";
 
-  /*
-   * note: OpenMapTiles (OMT) is applying length limit *after* line merge, Planetiler *before* merge. Hence,
-   * Planetiler produces fewer features with same limits. To counter that, limits here are 1/2 of those used in OMT.
-   * Result is not 100% same as from OMT but is closer.
-   */
   private static final ZoomFunction.MeterToPixelThresholds MIN_LENGTH = ZoomFunction.meterThresholds()
-    .put(6, 10_000)
-    .put(7, 10_000)
-    .put(8, 7_000)
-    .put(9, 4_000)
-    .put(10, 2_000)
-    .put(11, 1_000);
+    .put(6, 20_000)
+    .put(7, 20_000)
+    .put(8, 14_000)
+    .put(9, 8_000)
+    .put(10, 4_000)
+    .put(11, 2_000);
   private final boolean brunnel;
   private final boolean sizeForShield;
   private final boolean limitMerge;

--- a/src/main/java/org/openmaptiles/layers/TransportationName.java
+++ b/src/main/java/org/openmaptiles/layers/TransportationName.java
@@ -113,6 +113,11 @@ public class TransportationName implements
     .put(9, 8_000)
     .put(10, 4_000)
     .put(11, 2_000);
+  private static final ZoomFunction<Number> BUFFER_PIXEL_OVERRIDES =
+    ZoomFunction.fromMaxZoomThresholds(Map.of(
+      13, 256,
+      6, 256
+    ));
   private final boolean brunnel;
   private final boolean sizeForShield;
   private final boolean limitMerge;
@@ -255,7 +260,7 @@ public class TransportationName implements
 
     FeatureCollector.Feature feature = features.line(LAYER_NAME)
       .setBufferPixels(BUFFER_SIZE)
-      .setBufferPixelOverrides(MIN_LENGTH)
+      .setBufferPixelOverrides(BUFFER_PIXEL_OVERRIDES)
       // TODO abbreviate road names - can't port osml10n because it is AGPL
       .putAttrs(OmtLanguageUtils.getNames(element.source().tags(), translations))
       .setAttr(Fields.REF, ref)
@@ -308,7 +313,7 @@ public class TransportationName implements
     if (!nullOrEmpty(element.name())) {
       features.line(LAYER_NAME)
         .setBufferPixels(BUFFER_SIZE)
-        .setBufferPixelOverrides(MIN_LENGTH)
+        .setBufferPixelOverrides(BUFFER_PIXEL_OVERRIDES)
         .putAttrs(OmtLanguageUtils.getNames(element.source().tags(), translations))
         .setAttr(Fields.CLASS, "aerialway")
         .setAttr(Fields.SUBCLASS, element.aerialway())
@@ -323,7 +328,7 @@ public class TransportationName implements
     if (!nullOrEmpty(element.name())) {
       features.line(LAYER_NAME)
         .setBufferPixels(BUFFER_SIZE)
-        .setBufferPixelOverrides(MIN_LENGTH)
+        .setBufferPixelOverrides(BUFFER_PIXEL_OVERRIDES)
         .putAttrs(OmtLanguageUtils.getNames(element.source().tags(), translations))
         .setAttr(Fields.CLASS, element.shipway())
         .setMinPixelSize(0)

--- a/src/main/java/org/openmaptiles/layers/TransportationName.java
+++ b/src/main/java/org/openmaptiles/layers/TransportationName.java
@@ -106,13 +106,18 @@ public class TransportationName implements
   private static final String LINK_TEMP_KEY = "__islink";
   private static final String RELATION_ID_TEMP_KEY = "__relid";
 
+  /*
+   * note: OpenMapTiles (OMT) is applying length limit *after* line merge, Planetiler *before* merge. Hence,
+   * Planetiler produces fewer features with same limits. To counter that, limits here are 1/2 of those used in OMT.
+   * Result is not 100% same as from OMT but is closer.
+   */
   private static final ZoomFunction.MeterToPixelThresholds MIN_LENGTH = ZoomFunction.meterThresholds()
-    .put(6, 20_000)
-    .put(7, 20_000)
-    .put(8, 14_000)
-    .put(9, 8_000)
-    .put(10, 4_000)
-    .put(11, 2_000);
+    .put(6, 10_000)
+    .put(7, 10_000)
+    .put(8, 7_000)
+    .put(9, 4_000)
+    .put(10, 2_000)
+    .put(11, 1_000);
   private final boolean brunnel;
   private final boolean sizeForShield;
   private final boolean limitMerge;


### PR DESCRIPTION
This PR adjusts `MIN_LENGTH` for `transportation_name` to 1/2 of values used in OpenMapTiles, to partially counter the effect of Planetiler applying the limit before merging (while OpenMapTiles is applying the limit after merging).

What is produced by OpenMapTiles/master: Rhode Island, Z9

![Screenshot-Rhode_Island-Z9-OMT-master](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/feca255f-780f-4b19-ab16-5e9167033c16)

What is produced by `phanecak-maptiler/planetiler-openmaptiles/omt_3_15_0`:

![Screenshot-Rhode_Island-Z9-PR-before](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/2ae45c9a-75b8-4b11-bde4-15b9e1806cbd)

And what is produced with adjustments in this PR:

![Screenshot from 2023-12-11 19-51-37-Z9](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/34386527-4561-4aad-9ee3-6c26c402256e)

Example of filtering:
- in OpenMapTiles: https://github.com/openmaptiles/openmaptiles/blob/master/layers/transportation_name/transportation_name.sql#L97
- in Planetiler: https://github.com/onthegomap/planetiler/blob/05011ee15d3a2b649bc309e5f17ca17ebe5420e1/planetiler-core/src/main/java/com/onthegomap/planetiler/FeatureMerge.java#L184

Note: Difference was observed while porting https://github.com/openmaptiles/openmaptiles/pull/1579 , hence same area used in screenshots here.