### PR TITLE
Add e-road and a-road for transportation z4

### DIFF
--- a/src/main/java/org/openmaptiles/layers/Transportation.java
+++ b/src/main/java/org/openmaptiles/layers/Transportation.java
@@ -142,7 +142,9 @@ public class Transportation implements
   private static final Set<RouteNetwork> TRUNK_AS_MOTORWAY_BY_NETWORK = Set.of(
     RouteNetwork.CA_TRANSCANADA,
     RouteNetwork.CA_PROVINCIAL_ARTERIAL,
-    RouteNetwork.US_INTERSTATE
+    RouteNetwork.US_INTERSTATE,
+    RouteNetwork.E_ROAD,
+    RouteNetwork.A_ROAD
   );
   private static final Set<String> CA_AB_PRIMARY_AS_ARTERIAL_BY_REF = Set.of(
     "2", "3", "4"
@@ -291,7 +293,11 @@ public class Transportation implements
       String network = relation.getString("network");
       String ref = relation.getString("ref");
 
-      if ("US:I".equals(network)) {
+      if ("e-road".equals(network)) {
+        networkType = RouteNetwork.E_ROAD;
+      } else if ("AsianHighway".equals(network)) {
+        networkType = RouteNetwork.A_ROAD;
+      } else if ("US:I".equals(network)) {
         networkType = RouteNetwork.US_INTERSTATE;
       } else if ("US:US".equals(network)) {
         networkType = RouteNetwork.US_HIGHWAY;
@@ -645,7 +651,9 @@ public class Transportation implements
     GB_PRIMARY("gb-primary", "omt-gb-primary"),
     IE_MOTORWAY("ie-motorway", "omt-ie-motorway"),
     IE_NATIONAL("ie-national", "omt-ie-national"),
-    IE_REGIONAL("ie-regional", "omt-ie-regional");
+    IE_REGIONAL("ie-regional", "omt-ie-regional"),
+    E_ROAD("e-road", null),
+    A_ROAD("a-road", null);
 
     final String name;
     final String network;

--- a/src/test/java/org/openmaptiles/layers/TransportationTest.java
+++ b/src/test/java/org/openmaptiles/layers/TransportationTest.java
@@ -2041,4 +2041,58 @@ class TransportationTest extends AbstractLayerTest {
       "name:en", "Ayalon South"
     )), result);
   }
+
+  @Test
+  void testARoad() {
+    var rel = new OsmElement.Relation(1);
+    rel.setTag("type", "route");
+    rel.setTag("route", "road");
+    rel.setTag("network", "AsianHighway");
+    rel.setTag("ref", "AH11");
+
+    FeatureCollector features = process(lineFeatureWithRelation(
+      profile.preprocessOsmRelation(rel),
+      Map.of(
+        "highway", "trunk"
+      )));
+
+    assertFeatures(13, List.of(Map.of(
+      "_layer", "transportation",
+      "class", "trunk",
+      "network", "a-road",
+      "_minzoom", 4
+    ), Map.of(
+      "_layer", "transportation_name",
+      "class", "trunk",
+      "ref", "AH11",
+      "network", "a-road"
+    )), features);
+  }
+
+  @Test
+  void testERoad() {
+    var rel = new OsmElement.Relation(1);
+    rel.setTag("type", "route");
+    rel.setTag("route", "road");
+    rel.setTag("network", "e-road");
+    rel.setTag("ref", "E 50");
+
+    FeatureCollector features = process(lineFeatureWithRelation(
+      profile.preprocessOsmRelation(rel),
+      Map.of(
+        "highway", "motorway"
+      )));
+
+    assertFeatures(13, List.of(Map.of(
+      "_layer", "transportation",
+      "class", "motorway",
+      "network", "e-road",
+      "_minzoom", 4
+    ), Map.of(
+      "_layer", "transportation_name",
+      "class", "motorway",
+      "ref", "E 50",
+      "network", "e-road"
+    )), features);
+  }
 }

--- a/src/test/java/org/openmaptiles/layers/TransportationTest.java
+++ b/src/test/java/org/openmaptiles/layers/TransportationTest.java
@@ -519,8 +519,8 @@ class TransportationTest extends AbstractLayerTest {
       "_layer", "transportation_name",
       "class", "trunk",
       "name", "<null>",
-      "ref", "S7",
-      "ref_length", 2,
+      "ref", "E 28",
+      "ref_length", 4,
       "route_1", "e-road=E 28",
       "route_2", "e-road=E 77"
     )), rendered);


### PR DESCRIPTION
This re-implements following OpenMapTiles pull-request into `planetiler-openmaptiles`:

* https://github.com/openmaptiles/openmaptiles/pull/1619

Screenshots from area used for upstream PR:

- `a-road`:

![Screenshot from 2024-01-27 14-57-50](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/62ae472d-9c07-4de1-9d92-0aacf0ba5bdf)

- `e-road`:

![Screenshot from 2024-01-27 16-04-25](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/ff3e06ce-abc3-4d18-8dd8-dbd9ae40d77a)
