### PR TITLE
Missing gulfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ available options.
   lines, to revert this behavior set `--transportation-name-brunnel=true`
 - `rank` field on `mountain_peak` linestrings only has 3 levels (1: has wikipedia page and name, 2: has name, 3: no name
   or wikipedia page or name)
-- some line and polygon tolerances are different, can be tweaked with `--simplify-tolerance` parameter
+- Some line and polygon tolerances are different, can be tweaked with `--simplify-tolerance` parameter
+- For bigger bays whose label points show above Z9, centerline is used for Z9+
 
 ## Customizing
 

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.1</version>
         <configuration>
           <from>
             <image>

--- a/src/main/java/org/openmaptiles/layers/WaterName.java
+++ b/src/main/java/org/openmaptiles/layers/WaterName.java
@@ -82,6 +82,7 @@ public class WaterName implements
    */
 
   private static final Logger LOGGER = LoggerFactory.getLogger(WaterName.class);
+  private static final double LOG2 = Math.log(2);
   private static final Set<String> SEA_OR_OCEAN_PLACE = Set.of("sea", "ocean");
   private static final double IMPORTANT_MARINE_REGIONS_JOIN_DISTANCE =
     GeoUtils.metersToPixelAtEquator(0, 50_000) / 256d;
@@ -214,35 +215,49 @@ public class WaterName implements
   @Override
   public void process(Tables.OsmWaterPolygon element, FeatureCollector features) {
     if (nullIfEmpty(element.name()) != null) {
-      Geometry centerlineGeometry = lakeCenterlines.get(element.source().id());
-      FeatureCollector.Feature feature;
-      int minzoom = 9;
-      String place = element.place();
-      String clazz;
-      if ("bay".equals(element.natural())) {
-        clazz = FieldValues.CLASS_BAY;
-      } else if ("sea".equals(place)) {
-        clazz = FieldValues.CLASS_SEA;
-      } else {
-        clazz = FieldValues.CLASS_LAKE;
-        minzoom = 3;
+      try {
+        Geometry centerlineGeometry = lakeCenterlines.get(element.source().id());
+        FeatureCollector.Feature feature;
+        int minzoom = 9;
+        String place = element.place();
+        String clazz;
+        if ("bay".equals(element.natural())) {
+          clazz = FieldValues.CLASS_BAY;
+        } else if ("sea".equals(place)) {
+          clazz = FieldValues.CLASS_SEA;
+        } else {
+          clazz = FieldValues.CLASS_LAKE;
+          minzoom = 3;
+        }
+        if (centerlineGeometry != null) {
+          // prefer lake centerline if it exists
+          // TODO: ... but by doing this we're diverging from OpenMapTiles since say "Notre Dame Bay" is shown:
+          // 1) OpenMapTiles: as point from Z7
+          // 2) planetiler-openmaptiles: as line from Z9
+          feature = features.geometry(LAYER_NAME, centerlineGeometry)
+            .setMinPixelSizeBelowZoom(13, 6d * element.name().length());
+        } else {
+          // otherwise just use a label point inside the lake
+          feature = features.pointOnSurface(LAYER_NAME);
+          // Show a label if a water feature covers at least 1/4 of a tile or z14+
+          Geometry geometry = element.source().worldGeometry();
+          double area = geometry.getArea();
+          minzoom = (int) Math.floor(-1d - Math.log(Math.sqrt(area)) / LOG2);
+          if (place != null && SEA_OR_OCEAN_PLACE.contains(place)) {
+            minzoom = Math.clamp(minzoom, 0, 14);
+          } else {
+            minzoom = Math.clamp(minzoom, 3, 14);
+          }
+        }
+        feature
+          .setAttr(Fields.CLASS, clazz)
+          .setBufferPixels(BUFFER_SIZE)
+          .putAttrs(OmtLanguageUtils.getNames(element.source().tags(), translations))
+          .setAttr(Fields.INTERMITTENT, element.isIntermittent() ? 1 : 0)
+          .setMinZoom(minzoom);
+      } catch (GeometryException e) {
+        e.log(stats, "omt_water_polygon", "Unable to get geometry for water polygon " + element.source().id());
       }
-      if (centerlineGeometry != null) {
-        // prefer lake centerline if it exists
-        feature = features.geometry(LAYER_NAME, centerlineGeometry)
-          .setMinPixelSizeBelowZoom(13, 6d * element.name().length());
-      } else {
-        // otherwise just use a label point inside the lake
-        feature = features.pointOnSurface(LAYER_NAME)
-          .setMinZoom(place != null && SEA_OR_OCEAN_PLACE.contains(place) ? 0 : 3)
-          .setMinPixelSize(128); // tiles are 256x256, so 128x128 is 1/4 of a tile
-      }
-      feature
-        .setAttr(Fields.CLASS, clazz)
-        .setBufferPixels(BUFFER_SIZE)
-        .putAttrs(OmtLanguageUtils.getNames(element.source().tags(), translations))
-        .setAttr(Fields.INTERMITTENT, element.isIntermittent() ? 1 : 0)
-        .setMinZoom(minzoom);
     }
   }
 


### PR DESCRIPTION
This PR fixes some missing gulfs, e.g. those shown when generated with [OpenMapTiles](https://github.com/openmaptiles/openmaptiles) but missing when generated with [planetiler-openmaptiles](https://github.com/openmaptiles/planetiler-openmaptiles).

[Gulf of Saint Lawrence](https://www.openstreetmap.org/relation/9428957), result from original `planetiler-openmaptiles` code (=current upstream `main` branch) on the left, result from code in this PR on the right:

- Z5:

![Screenshot from 2024-03-11 10-03-57](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/6420f33e-497d-45ec-9141-4dd8252677a3)

- Z6:

![Screenshot from 2024-03-11 10-04-40](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/00bd5da4-eaea-4e0e-9f7b-f2ac085213d5)

[Notre Dame Bay](https://www.openstreetmap.org/relation/13622314), original on the left, current code on the right:

- Z7:

![Screenshot from 2024-03-11 10-05-25](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/965d2ef4-3485-4596-bbbe-74de940d2c09)

- Z8:

![Screenshot from 2024-03-11 10-05-53](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/aa6b2339-343a-4a87-892d-8a0b047bd6b1)

- Z9:

![Screenshot from 2024-03-11 10-06-50](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/5294e536-5b34-4d17-86b0-9f25d1de2b56)

Plus a difference between OpenMapTiles and `planetiler-openmaptiles` regarding bigger bays (those shown from between Z3 and Z8): OpenMapTiles uses only label points, `planetiler-openmaptiles` switches from point to centerline for Z9+: OpenMapTiles result on the left, current code on the right:

![Screenshot from 2024-03-11 10-08-24](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/99521ad3-7891-4808-8d0e-611eef2f11c6)
