### PR TITLE
Landuse residential fix

### DIFF
--- a/src/main/java/org/openmaptiles/layers/Landuse.java
+++ b/src/main/java/org/openmaptiles/layers/Landuse.java
@@ -87,11 +87,10 @@ public class Landuse implements
   public void processNaturalEarth(String table, SourceFeature feature, FeatureCollector features) {
     if ("ne_50m_urban_areas".equals(table)) {
       Double scalerank = Parse.parseDoubleOrNull(feature.getTag("scalerank"));
-      if (scalerank != null && scalerank <= 2) {
-        features.polygon(LAYER_NAME).setBufferPixels(BUFFER_SIZE)
-          .setAttr(Fields.CLASS, FieldValues.CLASS_RESIDENTIAL)
-          .setZoomRange(4, 5);
-      }
+      int minzoom = (scalerank != null && scalerank <= 2) ? 4 : 5;
+      features.polygon(LAYER_NAME).setBufferPixels(BUFFER_SIZE)
+        .setAttr(Fields.CLASS, FieldValues.CLASS_RESIDENTIAL)
+        .setZoomRange(minzoom, 5);
     }
   }
 

--- a/src/test/java/org/openmaptiles/layers/LanduseTest.java
+++ b/src/test/java/org/openmaptiles/layers/LanduseTest.java
@@ -19,7 +19,8 @@ class LanduseTest extends AbstractLayerTest {
     assertFeatures(0, List.of(Map.of(
       "_layer", "landuse",
       "class", "residential",
-      "_buffer", 4d
+      "_buffer", 4d,
+      "_minzoom", 4
     )), process(SimpleFeature.create(
       GeoUtils.worldToLatLonCoords(rectangle(0, Math.sqrt(1))),
       Map.of("scalerank", 1.9),
@@ -27,7 +28,12 @@ class LanduseTest extends AbstractLayerTest {
       "ne_50m_urban_areas",
       0
     )));
-    assertFeatures(0, List.of(), process(SimpleFeature.create(
+    assertFeatures(0, List.of(Map.of(
+      "_layer", "landuse",
+      "class", "residential",
+      "_buffer", 4d,
+      "_minzoom", 5
+    )), process(SimpleFeature.create(
       GeoUtils.worldToLatLonCoords(rectangle(0, Math.sqrt(1))),
       Map.of("scalerank", 2.1),
       OpenMapTilesProfile.NATURAL_EARTH_SOURCE,


### PR DESCRIPTION
Some differences were found in layer `landuse` for residential areas at Z4-Z8 between output dine with OpenMapTiles and `planetiler-openmaptiles` (both "3.15 SNAPSHOT" versions). This PR attempts to align that.

While fix for features comming from NAtural Earth is quite straightforward, polygon manipulations for features coming from OSM do not match OpenMapTiles exactly, since that would require adjustments of `planetiler-core` or more code in this PR, hence the goal is to make the results as similar as possible with as little changed code as possible.

Tested on area roughly around [Gliwice](https://www.openstreetmap.org/relation/2103532). First image if from current `planetiler-openmaptiles` snapshot, second image is from current OpenMapTiles snapshot and third image was generate with code from this PR, some layers were omitted in `planetiler-openmaptiles` output to speed-up testing:

- Z5:

![Screenshot from 2024-03-12 19-45-33](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/b91b40f1-1712-4391-a566-98645a9b2d22)

![Screenshot from 2024-03-12 19-45-39](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/890e1949-04c4-4368-977f-8c64376ef810)

![Screenshot from 2024-03-12 19-45-44](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/e7856c4b-4a08-4f70-8208-45233387ac6a)

- Z6:

![Screenshot from 2024-03-12 19-55-40](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/4a583c69-aeb7-4c19-8b9d-372c8cc3f139)

![Screenshot from 2024-03-12 19-55-46](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/f17c91a5-779b-4b93-907c-00f5b4250e3f)

![Screenshot from 2024-03-12 19-55-51](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/f370845e-874b-4743-99fc-d4c0f72da209)

- Z7:

![Screenshot from 2024-03-12 20-00-59](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/55ab3e7b-bf9a-4cf7-831c-302cc91927cc)

![Screenshot from 2024-03-12 20-01-04](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/4c299d70-ffa8-4496-ae08-768f1df9cfb0)

![Screenshot from 2024-03-12 20-01-07](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/d3e999e2-ed22-40df-a6ec-efab4635ce54)

-Z8:

![Screenshot from 2024-03-12 20-04-07](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/e4733c4f-adc4-44bc-b717-4f29f4e60483)

![Screenshot from 2024-03-12 20-04-12](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/729bbc52-cc89-4dfd-a2fb-3e70c0da0ecf)

![Screenshot from 2024-03-12 20-04-15](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/4005830e-9d82-40b8-affd-1468d4a17048)

To make it hopefully more organized, lets have those pictures also in different order:

- current `planetiler-openmaptiles` 3.15 SNAPSHOT, from Z5 to Z8:

![Screenshot from 2024-03-12 19-45-33](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/b91b40f1-1712-4391-a566-98645a9b2d22)

![Screenshot from 2024-03-12 19-55-40](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/4a583c69-aeb7-4c19-8b9d-372c8cc3f139)

![Screenshot from 2024-03-12 20-00-59](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/55ab3e7b-bf9a-4cf7-831c-302cc91927cc)

![Screenshot from 2024-03-12 20-04-07](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/e4733c4f-adc4-44bc-b717-4f29f4e60483)

- current OpenMapTiles 3.15 SNAPSHOT:

![Screenshot from 2024-03-12 19-45-39](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/890e1949-04c4-4368-977f-8c64376ef810)

![Screenshot from 2024-03-12 19-55-46](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/f17c91a5-779b-4b93-907c-00f5b4250e3f)

![Screenshot from 2024-03-12 20-01-04](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/4c299d70-ffa8-4496-ae08-768f1df9cfb0)

![Screenshot from 2024-03-12 20-04-12](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/729bbc52-cc89-4dfd-a2fb-3e70c0da0ecf)

- this PR:

![Screenshot from 2024-03-12 19-45-44](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/e7856c4b-4a08-4f70-8208-45233387ac6a)

![Screenshot from 2024-03-12 19-55-51](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/f370845e-874b-4743-99fc-d4c0f72da209)

![Screenshot from 2024-03-12 20-01-07](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/d3e999e2-ed22-40df-a6ec-efab4635ce54)

![Screenshot from 2024-03-12 20-04-15](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/4005830e-9d82-40b8-affd-1468d4a17048)
