### PR TITLE
Fix maritime low zooms

### DIFF
--- a/src/main/java/org/openmaptiles/layers/Boundary.java
+++ b/src/main/java/org/openmaptiles/layers/Boundary.java
@@ -263,8 +263,7 @@ public class Boundary implements
           feature.hasTag("natural", "coastline") ||
           feature.hasTag("boundary_type", "maritime");
         int minzoom =
-          (disputed && minAdminLevel == 2) ? 3 :
-            ((maritime || disputed) && minAdminLevel == 2) ? 4 :
+          (maritime && minAdminLevel == 2) ? 4 :
             minAdminLevel <= 4 ? 5 :
             minAdminLevel <= 6 ? 9 :
             minAdminLevel <= 8 ? 11 : 12;

--- a/src/test/java/org/openmaptiles/layers/BoundaryTest.java
+++ b/src/test/java/org/openmaptiles/layers/BoundaryTest.java
@@ -392,7 +392,7 @@ class BoundaryTest extends AbstractLayerTest {
     assertFeatures(3, List.of(Map.of(
       "_layer", "boundary",
       "_type", "line",
-      "_minzoom", 3,
+      "_minzoom", 5,
 
       "disputed", 1,
       "maritime", 0,


### PR DESCRIPTION
This re-implements following OpenMapTiles pull-request into `planetiler-openmaptiles`:

- https://github.com/openmaptiles/openmaptiles/pull/1644

Test areas: left = current `omt_3_15_5` a.k.a. "upstream `main`", right = current PR

- Canada, Z3:

![Screenshot from 2024-03-21 21-28-31](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/1ebe4c47-cc7a-46ff-ae5a-0eb86df37213)

- Peru, Z3:

![Screenshot from 2024-03-21 21-26-53](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/73a66aad-902b-48a2-897d-ae2ddfef9b66)

- India, Z4:

![Screenshot from 2024-03-21 21-24-25](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/0459e306-9ad4-489a-891a-b4ed42063298)

Note: Screenshots done with `tileserver-gl-light` hence maybe the difference regarding how disputed borders are rendered. But some "double lines" can be still spotted in the left part of India screenshot anyway.

Correction for commit messages: "_OSM boundaries only for Z5+, non-disputed for Z4+_" -> "_OSM boundaries only for Z5+, maritime + admin_level=2 for Z4+_"