### PR TITLE
NE lakes with OSM IDs

### DIFF
--- a/src/main/java/org/openmaptiles/layers/Water.java
+++ b/src/main/java/org/openmaptiles/layers/Water.java
@@ -84,7 +84,7 @@ public class Water implements
 
   // smallest NE lake is around 4.42E-13, smallest matching OSM lake is 9.34E-13, this is slightly bellow that
   // and approx. 33% of OSM features are smaller than this, hence to save some CPU cycles:
-  private static final double SMALLEST_OSM_LAKE_AREA = Math.pow(4, -20);
+  private static final double OSM_ID_MATCH_AREA_LIMIT = Math.pow(4, -20);
 
   private final MultiExpression.Index<String> classMapping;
   private final PlanetilerConfig config;
@@ -201,7 +201,7 @@ public class Water implements
 
       // if OSM lake is too small for Z6 (e.g. area bellow ~4px) we assume there is no matching NE lake
       Geometry geom = element.source().worldGeometry();
-      if (geom.getArea() < SMALLEST_OSM_LAKE_AREA) {
+      if (geom.getArea() < OSM_ID_MATCH_AREA_LIMIT) {
         return;
       }
 

--- a/src/main/java/org/openmaptiles/layers/Water.java
+++ b/src/main/java/org/openmaptiles/layers/Water.java
@@ -82,8 +82,9 @@ public class Water implements
    * which infers ocean polygons by preprocessing all coastline elements.
    */
 
-  // smallest NE lake is around 4.42E-13, this is roughly that and approx. 23% of OSM features are smaller than this:
-  private static final double SMALLEST_OSM_LAKE_AREA = Math.pow(4, -20.5);
+  // smallest NE lake is around 4.42E-13, smallest matching OSM lake is 9.34E-13, this is slightly bellow that
+  // and approx. 33% of OSM features are smaller than this, hence to save some CPU cycles:
+  private static final double SMALLEST_OSM_LAKE_AREA = Math.pow(4, -20);
 
   private final MultiExpression.Index<String> classMapping;
   private final PlanetilerConfig config;

--- a/src/main/java/org/openmaptiles/layers/Water.java
+++ b/src/main/java/org/openmaptiles/layers/Water.java
@@ -82,8 +82,8 @@ public class Water implements
    * which infers ocean polygons by preprocessing all coastline elements.
    */
 
-  // smallest NE lake is around 4.42E-13, this is roughly 1/2 of that and approx 17% of OSM features are smaller than this:
-  private static final double SMALLEST_OSM_LAKE_AREA = Math.pow(4, -21);
+  // smallest NE lake is around 4.42E-13, this is roughly that and approx. 23% of OSM features are smaller than this:
+  private static final double SMALLEST_OSM_LAKE_AREA = Math.pow(4, -20.5);
 
   private final MultiExpression.Index<String> classMapping;
   private final PlanetilerConfig config;
@@ -210,7 +210,7 @@ public class Water implements
       for (var index : neLakeIndexes.values()) {
         var items = index.query(envelope);
         if (items.size() == 1) {
-          if (items.getFirst()instanceof LakeInfo lakeInfo) {
+          if (items.getFirst() instanceof LakeInfo lakeInfo) {
             fillOsmIdIntoNeLake(element, geom, lakeInfo);
           }
         } else if (!items.isEmpty()) {

--- a/src/test/java/org/openmaptiles/layers/WaterTest.java
+++ b/src/test/java/org/openmaptiles/layers/WaterTest.java
@@ -2,8 +2,10 @@ package org.openmaptiles.layers;
 
 import static com.onthegomap.planetiler.TestUtils.rectangle;
 
+import com.onthegomap.planetiler.FeatureCollector;
 import com.onthegomap.planetiler.geo.GeoUtils;
 import com.onthegomap.planetiler.reader.SimpleFeature;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,20 +17,6 @@ class WaterTest extends AbstractLayerTest {
 
   @Test
   void testWaterNaturalEarth() {
-    assertFeatures(0, List.of(Map.of(
-      "class", "lake",
-      "intermittent", "<null>",
-      "_layer", "water",
-      "_type", "polygon",
-      "_minzoom", 0
-    )), process(SimpleFeature.create(
-      rectangle(0, 10),
-      Map.of(),
-      OpenMapTilesProfile.NATURAL_EARTH_SOURCE,
-      "ne_110m_lakes",
-      0
-    )));
-
     assertFeatures(0, List.of(Map.of(
       "class", "ocean",
       "intermittent", "<null>",
@@ -44,19 +32,6 @@ class WaterTest extends AbstractLayerTest {
     )));
 
     assertFeatures(6, List.of(Map.of(
-      "class", "lake",
-      "_layer", "water",
-      "_type", "polygon",
-      "_maxzoom", 5
-    )), process(SimpleFeature.create(
-      rectangle(0, 10),
-      Map.of(),
-      OpenMapTilesProfile.NATURAL_EARTH_SOURCE,
-      "ne_10m_lakes",
-      0
-    )));
-
-    assertFeatures(6, List.of(Map.of(
       "class", "ocean",
       "_layer", "water",
       "_type", "polygon",
@@ -68,6 +43,92 @@ class WaterTest extends AbstractLayerTest {
       "ne_10m_ocean",
       0
     )));
+  }
+
+  @Test
+  void testLakeNaturalEarthByIntersection() {
+    final var polygon = rectangle(0, 0.1);
+    // NE lakes:
+    process(SimpleFeature.create(
+      polygon,
+      Map.of(),
+      OpenMapTilesProfile.NATURAL_EARTH_SOURCE,
+      "ne_110m_lakes",
+      0
+    ));
+    process(SimpleFeature.create(
+      polygon,
+      Map.of(),
+      OpenMapTilesProfile.NATURAL_EARTH_SOURCE,
+      "ne_10m_lakes",
+      0
+    ));
+    // OSM lake to take the ID from:
+    process(SimpleFeature.create(
+      polygon,
+      new HashMap<>(Map.<String, Object>of(
+        "natural", "water",
+        "water", "reservoir"
+      )),
+      OpenMapTilesProfile.OSM_SOURCE,
+      null,
+      123
+    ));
+
+    List<FeatureCollector.Feature> features = new ArrayList<>();
+    profile.finish(OpenMapTilesProfile.OSM_SOURCE, new FeatureCollector.Factory(params, stats), features::add);
+    assertFeatures(0, List.of(Map.of(
+      "class", "lake",
+      "intermittent", "<null>",
+      "id", 123L,
+      "_layer", "water",
+      "_type", "polygon",
+      "_minzoom", 0,
+      "_maxzoom", 1
+    ), Map.of(
+      "class", "lake",
+      "intermittent", "<null>",
+      "id", 123L,
+      "_layer", "water",
+      "_type", "polygon",
+      "_minzoom", 4,
+      "_maxzoom", 5
+    )), features);
+  }
+
+  @Test
+  void testLakeNaturalEarthByName() {
+    final var polygon = rectangle(0, 0.1);
+    // NE lake:
+    process(SimpleFeature.create(
+      polygon,
+      Map.of("name", "Test Lake"),
+      OpenMapTilesProfile.NATURAL_EARTH_SOURCE,
+      "ne_50m_lakes",
+      0
+    ));
+    // OSM lake to take the ID from:
+    process(SimpleFeature.create(
+      polygon,
+      new HashMap<>(Map.<String, Object>of(
+        "name", "Test Lake",
+        "natural", "water",
+        "water", "reservoir"
+      )),
+      OpenMapTilesProfile.OSM_SOURCE,
+      null,
+      123
+    ));
+
+    List<FeatureCollector.Feature> features = new ArrayList<>();
+    profile.finish(OpenMapTilesProfile.OSM_SOURCE, new FeatureCollector.Factory(params, stats), features::add);
+    assertFeatures(0, List.of(Map.of(
+      "class", "lake",
+      "id", 123L,
+      "_layer", "water",
+      "_minzoom", 2,
+      "_maxzoom", 3
+    )), features);
   }
 
   @Test

--- a/src/test/java/org/openmaptiles/layers/WaterTest.java
+++ b/src/test/java/org/openmaptiles/layers/WaterTest.java
@@ -316,28 +316,7 @@ class WaterTest extends AbstractLayerTest {
 
   @Test
   void testLakeZoomLevels() {
-    assertCoversZoomRange(0, 14, "water",
-      process(SimpleFeature.create(
-        rectangle(0, 10),
-        Map.of(),
-        OpenMapTilesProfile.NATURAL_EARTH_SOURCE,
-        "ne_110m_lakes",
-        0
-      )),
-      process(SimpleFeature.create(
-        rectangle(0, 10),
-        Map.of(),
-        OpenMapTilesProfile.NATURAL_EARTH_SOURCE,
-        "ne_50m_lakes",
-        0
-      )),
-      process(SimpleFeature.create(
-        rectangle(0, 10),
-        Map.of(),
-        OpenMapTilesProfile.NATURAL_EARTH_SOURCE,
-        "ne_10m_lakes",
-        0
-      )),
+    assertCoversZoomRange(6, 14, "water",
       process(SimpleFeature.create(
         rectangle(0, 10),
         Map.of(


### PR DESCRIPTION
This fixes https://github.com/openmaptiles/planetiler-openmaptiles/issues/15 following first option, replicating (but I guess not 100%) what OpenMapTiles does in https://github.com/openmaptiles/openmaptiles/blob/af6dc684efa05f3eebd3d9a206566d4635c036c6/layers/water/water.sql#L23.

Test area: [Lake Athabasca, Canada](https://www.openstreetmap.org/relation/2791738)

![Screenshot from 2024-03-23 19-32-53](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/434e3eb1-5be5-4872-8fa2-b2b7d43fb25e)
