### PR TITLE
Fix borders z0-z4

### DIFF
--- a/src/main/java/org/openmaptiles/layers/Boundary.java
+++ b/src/main/java/org/openmaptiles/layers/Boundary.java
@@ -179,8 +179,17 @@ public class Boundary implements
     BoundaryInfo info = switch (table) {
       case "ne_110m_admin_0_boundary_lines_land" -> new BoundaryInfo(2, 0, 0);
       case "ne_50m_admin_0_boundary_lines_land" -> new BoundaryInfo(2, 1, 3);
-      case "ne_10m_admin_0_boundary_lines_land" -> feature.hasTag("featurecla", "Lease limit") ? null :
-        new BoundaryInfo(2, 4, 4);
+      case "ne_10m_admin_0_boundary_lines_land" -> {
+        boolean isDisputedSouthSudanAndKenya = false;
+        if (disputed) {
+          String left = feature.getString("adm0_left");
+          String right = feature.getString("adm0_right");
+          isDisputedSouthSudanAndKenya = "South Sudan".equals(left) && "Kenya".equals(right);
+        }
+        yield isDisputedSouthSudanAndKenya ? new BoundaryInfo(2, 1, 4) :
+          feature.hasTag("featurecla", "Lease limit") ? null :
+          new BoundaryInfo(2, 4, 4);
+      }
       case "ne_10m_admin_1_states_provinces_lines" -> {
         Double minZoom = Parse.parseDoubleOrNull(feature.getTag("min_zoom"));
         yield minZoom != null && minZoom <= 7 ? new BoundaryInfo(4, 1, 4) :

--- a/src/test/java/org/openmaptiles/layers/BoundaryTest.java
+++ b/src/test/java/org/openmaptiles/layers/BoundaryTest.java
@@ -104,11 +104,29 @@ class BoundaryTest extends AbstractLayerTest {
     assertFeatures(0, List.of(Map.of(
       "_layer", "boundary",
       "_type", "line",
+      "_minzoom", 4,
       "admin_level", 2
     )), process(SimpleFeature.create(
       newLineString(0, 0, 1, 1),
       Map.of(
         "featurecla", "International boundary (verify)"
+      ),
+      OpenMapTilesProfile.NATURAL_EARTH_SOURCE,
+      "ne_10m_admin_0_boundary_lines_land",
+      0
+    )));
+
+    assertFeatures(0, List.of(Map.of(
+      "_layer", "boundary",
+      "_type", "line",
+      "_minzoom", 1,
+      "admin_level", 2
+    )), process(SimpleFeature.create(
+      newLineString(0, 0, 1, 1),
+      Map.of(
+        "featurecla", "Disputed (please verify)",
+        "adm0_left", "South Sudan",
+        "adm0_right", "Kenya"
       ),
       OpenMapTilesProfile.NATURAL_EARTH_SOURCE,
       "ne_10m_admin_0_boundary_lines_land",


### PR DESCRIPTION
This re-implements following OpenMapTiles pull-request into `planetiler-openmaptiles`:

- https://github.com/openmaptiles/openmaptiles/pull/1647

Test area: Disputed border between South Sudan and Kenya:

![Screenshot from 2024-03-27 12-57-40](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/8032fde5-3655-48fe-85fc-b986619a8c7f)
