### PR TITLE
Fix labels in water layer

### DIFF
--- a/src/main/java/org/openmaptiles/layers/WaterName.java
+++ b/src/main/java/org/openmaptiles/layers/WaterName.java
@@ -236,7 +236,7 @@ public class WaterName implements
           // note: Here we're diverging from OpenMapTiles: For bays with minzoom (based on area) point is used between
           // minzoom and Z8 and for Z9+ centerline is used, while OpenMaptiles sticks with points.
           setupOsmWaterPolygonFeature(
-            element, features.geometry(LAYER_NAME, centerlineGeometry), clazz, Math.min(minzoomCL, MINZOOM_BAY))  // TODO: drop the min(), not needed here
+            element, features.geometry(LAYER_NAME, centerlineGeometry), clazz, minzoomCL)
               .setMinPixelSizeBelowZoom(13, 6d * element.name().length());
         }
 


### PR DESCRIPTION
This fixes bug introduced in https://github.com/phanecak-maptiler/planetiler-openmaptiles/pull/41 : While bays are handled OK, lakes are not hence we get both a center line and a point at some zooms for some lakes.

Example: Great Lakes, left is output from the current code, right is output from the code in this PR:

![Screenshot from 2024-04-02 12-48-36](https://github.com/openmaptiles/planetiler-openmaptiles/assets/115141505/258f3b75-9d10-478f-996f-f63aad56e2cf)
