### PR TITLE
Fix z7-z4 roads

### DIFF
--- a/src/main/java/org/openmaptiles/layers/Transportation.java
+++ b/src/main/java/org/openmaptiles/layers/Transportation.java
@@ -261,9 +261,9 @@ public class Transportation implements
       return false;
     }
     return routeRelations.stream()
-        .map(RouteRelation::networkType)
-        .filter(Objects::nonNull)
-        .anyMatch(Z5_TRUNK_BY_NETWORK::contains);
+      .map(RouteRelation::networkType)
+      .filter(Objects::nonNull)
+      .anyMatch(Z5_TRUNK_BY_NETWORK::contains);
   }
 
   private static boolean isMotorwayWithNetworkForZ4(List<RouteRelation> routeRelations) {
@@ -535,6 +535,7 @@ public class Transportation implements
       }
     }
     String highway = element.highway();
+    String construction = element.construction();
 
     int minzoom;
     if ("pier".equals(element.manMade())) {
@@ -563,7 +564,7 @@ public class Transportation implements
       };
     }
 
-    if (isLink(highway)) {
+    if (isLink(highway) || isLink(construction)) {
       minzoom = Math.max(minzoom, 9);
     }
     return minzoom;

--- a/src/main/java/org/openmaptiles/layers/Transportation.java
+++ b/src/main/java/org/openmaptiles/layers/Transportation.java
@@ -153,8 +153,8 @@ public class Transportation implements
     RouteNetwork.A_ROAD
   );
   private static final Set<RouteNetwork> Z5_MOTORWAYS_BY_NETWORK = Set.of(
-      RouteNetwork.GB_TRUNK,
-      RouteNetwork.US_HIGHWAY
+    RouteNetwork.GB_TRUNK,
+    RouteNetwork.US_HIGHWAY
   );
   private static final Set<String> CA_AB_PRIMARY_AS_ARTERIAL_BY_REF = Set.of(
     "2", "3", "4"
@@ -269,10 +269,24 @@ public class Transportation implements
   private static boolean isMotorwayWithNetworkForZ4(List<RouteRelation> routeRelations) {
     // All roads in network included in osm_national_network except gb-trunk and us-highway
     return routeRelations.stream()
-        .map(RouteRelation::networkType)
-        .filter(Objects::nonNull)
-        .filter(nt -> !Z5_MOTORWAYS_BY_NETWORK.contains(nt))
-        .anyMatch(Z5_TRUNK_BY_NETWORK::contains);
+      .map(RouteRelation::networkType)
+      .filter(Objects::nonNull)
+      .filter(nt -> !Z5_MOTORWAYS_BY_NETWORK.contains(nt))
+      .anyMatch(Z5_TRUNK_BY_NETWORK::contains);
+  }
+
+  private static boolean isMotorwayWoNetworkForZ4(List<RouteRelation> routeRelations) {
+    // All motorways without network (e.g. EU, Asia, South America)
+    return routeRelations.stream()
+      .map(RouteRelation::networkType)
+      .noneMatch(Objects::nonNull);
+  }
+
+  private static boolean isMotorwayForZ4(List<RouteRelation> routeRelations) {
+    if (isMotorwayWoNetworkForZ4(routeRelations)) {
+      return true;
+    }
+    return isMotorwayWithNetworkForZ4(routeRelations);
   }
 
   private static boolean isDrivewayOrParkingAisle(String service) {
@@ -543,6 +557,8 @@ public class Transportation implements
           }
           yield (z5trunk) ? 5 : MINZOOMS.getOrDefault(clazz, Integer.MAX_VALUE);
         }
+        case FieldValues.CLASS_MOTORWAY -> isMotorwayForZ4(routeRelations) ?
+          MINZOOMS.getOrDefault(FieldValues.CLASS_MOTORWAY, Integer.MAX_VALUE) : 5;
         default -> MINZOOMS.getOrDefault(baseClass, Integer.MAX_VALUE);
       };
     }

--- a/src/test/java/org/openmaptiles/layers/TransportationTest.java
+++ b/src/test/java/org/openmaptiles/layers/TransportationTest.java
@@ -353,7 +353,7 @@ class TransportationTest extends AbstractLayerTest {
       "_layer", "transportation",
       "class", "trunk",
       "network", "us-state",
-      "_minzoom", 5
+      "_minzoom", 6
     ), Map.of(
       "_layer", "transportation_name",
       "class", "trunk",
@@ -1174,7 +1174,7 @@ class TransportationTest extends AbstractLayerTest {
       "_layer", "transportation",
       "class", "trunk",
       "network", "ca-provincial",
-      "_minzoom", 5
+      "_minzoom", 6
     ), Map.of(
       "_layer", "transportation_name",
       "class", "trunk",
@@ -1228,7 +1228,7 @@ class TransportationTest extends AbstractLayerTest {
       "_layer", "transportation",
       "class", "trunk",
       "network", "ca-provincial",
-      "_minzoom", 5
+      "_minzoom", 6
     ), Map.of(
       "_layer", "transportation_name",
       "class", "trunk",
@@ -1282,7 +1282,7 @@ class TransportationTest extends AbstractLayerTest {
       "_layer", "transportation",
       "class", "trunk",
       "network", "ca-provincial",
-      "_minzoom", 5
+      "_minzoom", 6
     ), Map.of(
       "_layer", "transportation_name",
       "class", "trunk",
@@ -1336,7 +1336,7 @@ class TransportationTest extends AbstractLayerTest {
       "_layer", "transportation",
       "class", "trunk",
       "network", "ca-provincial",
-      "_minzoom", 5
+      "_minzoom", 6
     ), Map.of(
       "_layer", "transportation_name",
       "class", "trunk",
@@ -1361,7 +1361,7 @@ class TransportationTest extends AbstractLayerTest {
     assertFeatures(13, List.of(Map.of(
       "_layer", "transportation",
       "class", "trunk",
-      "_minzoom", 5
+      "_minzoom", 6
     )), features);
     boolean caProvPresent = StreamSupport.stream(features.spliterator(), false)
       .flatMap(f -> f.getAttrsAtZoom(13).entrySet().stream())
@@ -1647,7 +1647,7 @@ class TransportationTest extends AbstractLayerTest {
     assertFeatures(13, List.of(Map.of(
       "_layer", "transportation",
       "class", "trunk",
-      "_minzoom", 5
+      "_minzoom", 4
     ), Map.of(
       "_layer", "transportation_name",
       "class", "trunk",
@@ -2149,7 +2149,7 @@ class TransportationTest extends AbstractLayerTest {
     assertFeatures(13, List.of(Map.of(
       "_layer", "transportation",
       "class", "trunk",
-      "_minzoom", 5
+      "_minzoom", 6
     ), Map.of(
       "_layer", "transportation_name",
       "class", "trunk",


### PR DESCRIPTION
This re-implements following OpenMapTiles pull-request into `planetiler-openmaptiles`:

* https://github.com/openmaptiles/openmaptiles/pull/1656

Combining series of SQL `WHERE` conditions into one set of Java conditions is thus quite complicated hence to keep the code simpler some "corner cases" were handled differently. That is still the case also in this PR: thorough analysis was not done but elements with `minzoom` different in SQL and in Java is estimated at 2k for whole Planet. At the end the main point is not "100% accuracy" but "close enough".

Some testing locations, left: "current code in main" vs. right: "code in this PR":

USA:

* Z4: 
![Screenshot from 2024-04-24 20-10-23](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/03bd7f30-6755-44bb-98ad-341120e6c059)

* Z5: 
![Screenshot from 2024-04-24 20-10-43](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/6b63b0c0-3d6b-4879-8f9e-fe0d123bf8a1)

Europe:

* Z4: 
![Screenshot from 2024-04-24 20-11-54](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/594bef88-817d-4ea4-bffe-2e35ea4ffeb1)

* Z5: 
![Screenshot from 2024-04-24 20-12-31](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/18f573ed-0c76-434a-b062-0c270aa0bcee)

Asia:

* Z4: 
![Screenshot from 2024-04-24 20-16-01](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/511e4d17-af59-4bfd-8cf7-4a25d1d725e4)

* Z5: 
![Screenshot from 2024-04-24 20-16-41](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/e078fd33-8808-4071-914c-acb4a80241cd)

note: Before both PRs (on 3.15 SNAPSHOT and also in 3.14) there were some differences between what was produced by OpenMapTiles and `planetiler-openmaptiles` related to how the zoom determination works:

* OpenMapTiles is taking all highways from Z11 and applying some filtering "WHERE" SQL statements in turns, e.g.:
  * for Z10 using `highway NOT IN ('tertiary', 'tertiary_link', 'busway', 'bus_guideway') AND construction NOT IN ('tertiary', 'tertiary_link', 'busway', 'bus_guideway')` for Z10,
  * For Z9 no filter, e.g. all from Z10 is taken into Z9
  * For Z8 using `highway IN ('motorway', 'trunk', 'primary') OR construction IN ('motorway', 'trunk', 'primary')` 
  * etc.
* `planetiler-openmaptiles` is determining `minzoom` all at one in "processing phase", e.g.:
  * `case FieldValues.CLASS_SERVICE -> isDrivewayOrParkingAisle(service(element.service())) ? 14 : 13`
  * etc.

Another difference is that merging in OpenMapTiles is done "before" (e.g. while processing source data to be used by subsequent stages) while `planetiler-openmaptiles` is doing that "after" (e.g. when encoding features for a particular zoom level and particular tile) which influences how highway lines are matched to networks.

This can be illustrated when comparing area from the upstream PR with output here:

![Screenshot from 2024-04-24 20-47-12](https://github.com/phanecak-maptiler/planetiler-openmaptiles/assets/115141505/eb9b41d8-37e0-4450-8d45-0888c74b0dce)

E.g. this PR "took out" some roads at Z5, example area roughly east of Saint Paul. But according to OpenMapTiles info that seems "correct", since major pieces of those lines are matched to networks which are classes as "us-state" and thus as "not for Z4-Z5":

- https://www.openstreetmap.org/relation/930971
- https://www.openstreetmap.org/relation/5904254
- https://www.openstreetmap.org/relation/451136
- etc.